### PR TITLE
fix: avoid waiting time when BufWinEnter, WinEnter

### DIFF
--- a/denops/coding-now/mod.ts
+++ b/denops/coding-now/mod.ts
@@ -131,7 +131,7 @@ start(async (vim) => {
     command! CodingNowRead call denops#request("${vim.name}", "getUserStatus", [])
     `);
   await vim.execute(`
-    command! CodingNowWrite call denops#request("${vim.name}", "changeUserStatus", ${messageContent})
+    command! CodingNowWrite call denops#notify("${vim.name}", "changeUserStatus", ${messageContent})
     `);
 
   await vim.execute(`


### PR DESCRIPTION
Avoided waiting time when entering a new buffer or switching buffers.